### PR TITLE
Fix maximum call stack error

### DIFF
--- a/transferEncoder.js
+++ b/transferEncoder.js
@@ -29,7 +29,7 @@ var consumer = function (buff) {
 }
 
 var padLeadingZeros = function (hex, byteSize) {
-  return (hex.length === byteSize * 2) ? hex : padLeadingZeros('0' + hex, byteSize)
+  return hex.padStart(byteSize * 2, '0')
 }
 
 module.exports = {


### PR DESCRIPTION
When you use multiple inputs and addresses have more than 1 transaction